### PR TITLE
comment regarding new rate limiting mechanism

### DIFF
--- a/setup/flavors/compose/mailu.env
+++ b/setup/flavors/compose/mailu.env
@@ -29,7 +29,7 @@ POSTMASTER={{ postmaster }}
 # Choose how secure connections will behave (value: letsencrypt, cert, notls, mail, mail-letsencrypt)
 TLS_FLAVOR={{ tls_flavor }}
 
-# Authentication rate limit per IP (per /24 on ipv4 and /48 on ipv6)
+# Authentication rate limit per IP for failed login attempts or non-existing accounts (per /24 on ipv4 and /48 on ipv6)
 {% if auth_ratelimit_ip > '0' %}
 AUTH_RATELIMIT_IP={{ auth_ratelimit_ip }}/hour
 {% endif %}


### PR DESCRIPTION
I was confused why you lowered it this dramatically, then saw this one https://github.com/Mailu/Mailu/commit/d20c217ae68213aa0d5236e3189d758322f77c05.

This just changes the comment to make it clear in the generated .env.

I'm still unsure, if such a low number makes sense, though. What about people on VPN/CGNAT?

From the changelog:

> Now the rate limiter will only take distinct attempts into account. We have two different types of checks:
> 
>     to prevent crendential bruteforce (an attacker trying to guess a password), we limit the maximal amount of attempts an attacker has for a given account (from any IP address).
> 
>     to prevent password spraying (an attacker trying the same common password on all accounts he can enumerate), we limit the maximal number of non-existing accounts an attacker can attempt to authenticate against from a given network subnet.

Maybe the wording is still wrong, and this does *not* blacklist an IP for trying 5 random accounts, but only the combination of IP+account. Then I can understand why you lowered it so much I suppose. Still seems like that would lock out VPN/TOR/similar users right away. The bots hit all day, thousands of times.

## What type of PR?

documentation

## What does this PR do?

clarify